### PR TITLE
Adding library and libraryTarget to webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,8 @@ module.exports = {
     path: path.resolve(__dirname, './dist'),
     filename: 'firststreet.js',
     publicPath: '/',
+    library: 'FirstStreet',
+    libraryTarget: 'umd',
   },
   target: 'node',
   plugins: [


### PR DESCRIPTION
- Adding library and libraryTarget to webpack; without it, it doesn't build correctly and package can't be used